### PR TITLE
update mpi instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -396,17 +396,9 @@ When using MPI, you should set these environment variables (put in your ~/.bashr
 ```bash
 export I_MPI_PORT_RANGE=50000:50500
 export btl_tcp_port_min_v4=1024
+unset SLURM_TASKS_PER_NODE
+unset SLURM_JOBID
 ```
-
-MPI is currently limited to a single node, and must be run without SLURM.  Since SLURM (srun) will be the default, you need to specify a different launcher using the -launcher option.
-
-For instance - either of these should work:
-```bash
-mpirun -launcher ssh -n 128 ./a.out
-mpirun -launcher fork -n 128 ./a.out
-```
-
-These are probably the same (ssh and fork), but honestly we don't know.  They seem to run in the same time.  Let us know if you decide one is a superior choice.
 
 Visit the [MPI with SYCL example page](etc/MPI.md) for a quick example of how to get a SYCL Hello World from 40 different connections to GPUs (40 ranks).
 


### PR DESCRIPTION
Simpler workaround for MPI issue. The launcher argument is not convenient when you are typing mpirun on the command line or use a script that needs to work in environments where the launcher argument is not correct.